### PR TITLE
Git global config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,6 +193,23 @@ setup() {
 		git config --global core.editor nano
 	fi
 
+	echo "Please enter your name"
+	echo "Example: Casey Edwards"
+	read -p $'Enter your name: ' USERSNAME
+
+	read -p $'Enter the your github email: ' GITHUBEMAIL
+
+  	while [[ ! ($GITHUBEMAIL =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$) ]];
+    	do
+			echo "Invalid email"
+			echo "Please check and re-enter your email when prompted"
+			read -p $'Enter the your github email: ' GITHUBEMAIL
+	done
+
+	git config --global user.name "$USERSNAME"
+ 	git config --global user.email $GITHUBEMAIL
+
+
 	echo "Ok! We've gotten everything setup and you should be ready to go!"
 	echo "Good luck in class!"
 	echo
@@ -205,6 +222,8 @@ setup() {
 	echo "                                               | |      "
 	echo "                                               |_|      "
 }
+
+
 
 # delay script execution until the entire file is transferred
 setup

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,24 @@ install-intellij(){
   brew install --cask intellij-idea
 }
 
+set-git-config(){
+	echo "Please enter your name"
+	echo "Example: Casey Edwards"
+	read -p $'Enter your name: ' USERSNAME
+
+	read -p $'Enter the your github email: ' GITHUBEMAIL
+
+  	while [[ ! ($GITHUBEMAIL =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$) ]];
+    	do
+			echo "Invalid email"
+			echo "Please check and re-enter your email when prompted"
+			read -p $'Enter the your github email: ' GITHUBEMAIL
+	done
+
+	git config --global user.name "$USERSNAME"
+ 	git config --global user.email $GITHUBEMAIL
+}
+
 setup() {
 	echo 'We are going to check if xcode and brew are installed, and if you have ssh keys setup.'
 	echo 'We will then setup our java development environment, including installing MySQL,'
@@ -193,22 +211,7 @@ setup() {
 		git config --global core.editor nano
 	fi
 
-	echo "Please enter your name"
-	echo "Example: Casey Edwards"
-	read -p $'Enter your name: ' USERSNAME
-
-	read -p $'Enter the your github email: ' GITHUBEMAIL
-
-  	while [[ ! ($GITHUBEMAIL =~ ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$) ]];
-    	do
-			echo "Invalid email"
-			echo "Please check and re-enter your email when prompted"
-			read -p $'Enter the your github email: ' GITHUBEMAIL
-	done
-
-	git config --global user.name "$USERSNAME"
- 	git config --global user.email $GITHUBEMAIL
-
+	set-git-config
 
 	echo "Ok! We've gotten everything setup and you should be ready to go!"
 	echo "Good luck in class!"


### PR DESCRIPTION
This PR will prompt and set the student's git global config to their actual email and name and not the system's name and email.
^ This is an issue when the student is not using a mac book that is not theirs.